### PR TITLE
add peer source parameter to magnet uris

### DIFF
--- a/html/beps/bep_0009.rst
+++ b/html/beps/bep_0009.rst
@@ -119,7 +119,7 @@ magnet URI format
 
 The magnet URI format is::
 
-	magnet:?xt=urn:btih:<info-hash>&dn=<name>&tr=<tracker-url>&peer=<peer-address>
+	magnet:?xt=urn:btih:<info-hash>&dn=<name>&tr=<tracker-url>&x.pe=<peer-address>
 
 <info-hash>
 	Is the info-hash hex encoded, for a total of 40 characters. For
@@ -136,9 +136,9 @@ The magnet URI format is::
 ``xt`` is the only mandatory parameter. ``dn`` is the display name that may be
 used by the client to display while waiting for metadata. ``tr`` is a tracker
 url, if there is one. If there are multiple trackers, multiple ``tr`` entries
-may be included. The same applies for ``peer`` entries.
+may be included. The same applies for ``x.pe`` entries.
 
-``dn``, ``tr`` and ``peer`` are all optional.
+``dn``, ``tr`` and ``x.pe`` are all optional.
 
 If no tracker is specified, the client SHOULD use the DHT (`BEP 0005`_) to acquire peers.
 

--- a/html/beps/bep_0009.rst
+++ b/html/beps/bep_0009.rst
@@ -7,6 +7,7 @@
 :Type:    Standards Track
 :Created: 31-Jan-2008
 :Post-History: 14-Oct-2012: point out that unrecognized message types should be ignored
+	16-May-2016: added peer source parameter to magnets
 
 The purpose of this extension is to allow clients to join a swarm and
 complete a download without the need of downloading a .torrent file
@@ -118,19 +119,26 @@ magnet URI format
 
 The magnet URI format is::
 
-	magnet:?xt=urn:btih:<info-hash>&dn=<name>&tr=<tracker-url>
+	magnet:?xt=urn:btih:<info-hash>&dn=<name>&tr=<tracker-url>&peer=<peer-address>
 
 <info-hash>
 	Is the info-hash hex encoded, for a total of 40 characters. For
 	compatability with existing links in the wild, clients should also
 	support the 32 character `base32`_ encoded info-hash.
+	
+<peer-address>
+	A peer address expressed as ``hostname:port``, ``ipv4-literal:port`` or ``[ipv6-literal]:port``.
+	This parameter can be included to initiate a direct metadata transfer between two clients while reducing the need for external peer sources.
+	It should only be included if the client can discover its public IP address and determine its reachability.
+	Note: Since no URI scheme identifier has been allocated for bittorrent ``xs=`` is not used for this purpose.
+	
 
 ``xt`` is the only mandatory parameter. ``dn`` is the display name that may be
 used by the client to display while waiting for metadata. ``tr`` is a tracker
 url, if there is one. If there are multiple trackers, multiple ``tr`` entries
-may be included.
+may be included. The same applies for ``peer`` entries.
 
-Both ``dn`` and ``tr`` are optional.
+``dn``, ``tr`` and ``peer`` are all optional.
 
 If no tracker is specified, the client SHOULD use the DHT (`BEP 0005`_) to acquire peers.
 


### PR DESCRIPTION
I have seen people struggle on IRC with directly exchanging files without a tracker. This might help in some cases.

Clients could even use it as a common peer injection method for already-present torrents.

Another use would be supplying metadata from a dedicated metadata storage server via bittorrent instead of http.

If you're ok with an ad-hoc uri scheme we could also use `xs=bt://` or something like that.