### PR TITLE
BEP 20: add WebTorrent Desktop

### DIFF
--- a/html/beps/bep_0020.html
+++ b/html/beps/bep_0020.html
@@ -121,6 +121,7 @@ bytes are random.  An example is <tt class="docutils literal"><span class="pre">
 'UL' - uLeecher!
 'UT' - µTorrent
 'VG' - Vagaa
+'WD' - WebTorrent Desktop
 'WT' - BitLet
 'WW' - WebTorrent
 'WY' - FireTorrent

--- a/html/beps/bep_0020.rst
+++ b/html/beps/bep_0020.rst
@@ -81,6 +81,7 @@ Known clients that use this encoding style are
      'UL' - uLeecher!
      'UT' - µTorrent
      'VG' - Vagaa
+     'WD' - WebTorrent Desktop
      'WT' - BitLet
      'WW' - WebTorrent
      'WY' - FireTorrent


### PR DESCRIPTION
As discussed over email, WebTorrent Desktop is going to start using a new peer ID (`WD`) to differentiate it from users of the lower-level WebTorrent JS library (`WW`). This is purely for statistical purposes, not for user-agent based sniffing.