### PR TITLE
libtorrent file attributes

### DIFF
--- a/beps/bep_0047.rst
+++ b/beps/bep_0047.rst
@@ -1,4 +1,4 @@
-:BEP: ??
+:BEP: 47
 :Title: Padding files and extended file attributes 
 :Version: $Revision$
 :Last-Modified: $Date$

--- a/beps/bep_0047.rst
+++ b/beps/bep_0047.rst
@@ -74,7 +74,7 @@ Symlinks
 
 When the ``l`` attribute flag is present then the ``symlink path`` represents the *target* of the symlink while ``path`` indicates the location of the symlink itself.
   
-The ``length`` field of the symlink file should be zero. A non-zero length identical with the target file would improve backwards-compatibility but significantly complicate the management of piece hashing and duplicate pieces.
+The ``length`` of a symlink is always zero since it just points to another file already present in the piece space. For backwards compatibility the length=0 should be included when creating a torrent but clients implementing with this BEP should not require their presence on symlink files when parsing it so it can be omitted at some point in the future.
   
 Just like the regular path the symlink path is relative to the torrent root and must not contain ``..`` elements. It should also target another file within the torrent, otherwise a dangling symlink will be created.
   

--- a/beps/bep_attrs.rst
+++ b/beps/bep_attrs.rst
@@ -84,7 +84,7 @@ Padding files
 
 Padding files are synthetic files inserted into the file list to let the following file start at a piece boundary. That means their length should fill up the remainder of the piece length of the file that is supposed to be padded. For the calculation of piece hashes the content of padding file is all zeros.
 
-Clients aware of this extension don't need to write the padding files to disk and should also avoid requesting their contents in ``BT_REQUEST`` messages, but for backwards-compatibility they must service such requests.
+Clients aware of this extension don't need to write the padding files to disk and should also avoid requesting byte-ranges covering their contents, e.g. via ``request`` messages. But for backwards-compatibility they must service such requests.
 
 While clients implementing this extensions will have no use for the ``path`` of a padding file it should be included for backwards compatibility since it is a mandatory field in BEP 3 [#BEP-3]_.
 The recommended path is ``[".pad", "N"]`` where N is the length of the padding file in base10. This way clients not aware of this extension will write the padding files into a single directory, potentially re-using padding files from other torrents also stored in that directory.

--- a/beps/bep_attrs.rst
+++ b/beps/bep_attrs.rst
@@ -1,0 +1,119 @@
+:BEP: ??
+:Title: Padding files and extended file attributes 
+:Version: $Revision$
+:Last-Modified: $Date$
+:Author:  The 8472 <the8472.bep@infinite-source.de>
+:Status:  Draft
+:Type:    Standards Track
+:Content-Type: text/x-rst
+:Created: 05-Aug-2016
+:Post-History: 
+
+
+Padding files and extended file attributes
+==========================================
+
+This BEP specifies some additional file properties beyond those described those in BEP 3 [#BEP-3]_.
+
+
+Multi-file format
+
+.. parsed-literal::
+
+    {
+      "info":
+      {
+        "files":
+        {[
+          {
+            "attr": "phxl",
+            "sha1": *<20 bytes>*,
+            "symlink path": ["dir1", "dir2", "target.ext"],
+            ...
+          },
+          {
+            ...
+          }
+        ]},
+        ...
+      },
+      ...
+    }
+    
+Single-file format
+
+.. parsed-literal::
+
+
+    {
+      "info":
+      {
+        "attr": "hx",
+        "sha1": *<20 bytes>*,
+        ...
+      },
+      ...
+    }
+
+
+
+
+``attr``
+  A variable-length string. When present the characters each represent a file attribute. l = symlink, x = executable, h = hidden, p = padding file. Characters appear in no particular order and unknown characters should be ignored.
+  
+``sha1``
+  20 bytes. The SHA1 digest calculated over the contents of the file itself, without any additional padding. Can be used to aid file deduplication [#BEP-38]_.
+  
+``symlink path``
+  An array of strings. Path of the symlink target relative to the torrent root directory.
+
+
+Symlinks
+========
+
+When the ``l`` attribute flag is present then the ``symlink path`` represents the *target* of the symlink while ``path`` indicates the location of the symlink itself.
+  
+The ``length`` field of the symlink file should be zero. A non-zero length identical with the target file would improve backwards-compatibility but significantly complicate the management of piece hashing and duplicate pieces.
+  
+The target should be another file within the torrent, otherwise a dangling symlink will be created.
+  
+  
+Padding files
+=============
+
+Padding files are synthetic files inserted into the file list to let the following file start at a piece boundary. That means their length should fill up the remainder of the piece length of the file that is supposed to be padded. For the calculation of piece hashes the content of padding file is all zeros.
+
+Clients aware of this extension don't need to write the padding files to disk and should also avoid requesting their contents in ``BT_REQUEST`` messages, but for backwards-compatibility they must service such requests.
+
+While clients implementing this extensions will have no use for the ``path`` of a padding file it should be included for backwards compatibility since it is a mandatory field in BEP 3 [#BEP-3]_.
+The recommended path is ``[".pad", "N"]`` where N is the length of the padding file in base10. This way clients not aware of this extension will write the padding files into a single directory, potentially re-using padding files from other torrents also stored in that directory.
+
+To eventually allow the path field to be omitted clients implementing this BEP should not require it to be present on padding files.  
+
+Piece-aligned files simplify deduplication [#BEP-38]_ and the operations on mutable torrents [#BEP-39]_.
+
+The presence of padding files does not imply that all files are piece-aligned.
+
+
+Internally inconsistent torrents
+================================
+
+If used incorrectly or maliciously symlinks and padding files can result in internally inconsistent torrents which cannot finish downloading because they contain conflicting hash information. Similarly the ``sha1`` fields may in fact be inconsistent with the piece data and lead to failures after deduplication.
+
+Clients should ensure that adding and deduplicating such a torrent does not lead to loss of already existing data. 
+
+
+
+
+References
+==========
+
+.. [#BEP-3] BEP_0003. The BitTorrent Protocol Specification.
+   (http://www.bittorrent.org/beps/bep_0003.html)
+
+.. [#BEP-38] BEP_0038. Finding Local Data Via Torrent File Hints.
+   (http://www.bittorrent.org/beps/bep_0038.html)
+
+.. [#BEP-39] BEP_0039. Updating Torrents Via Feed URL.
+   (http://www.bittorrent.org/beps/bep_0039.html)   
+   

--- a/beps/bep_attrs.rst
+++ b/beps/bep_attrs.rst
@@ -13,7 +13,7 @@
 Padding files and extended file attributes
 ==========================================
 
-This BEP specifies some additional file properties beyond those described those in BEP 3 [#BEP-3]_.
+This BEP specifies some additional file properties beyond those described in BEP 3 [#BEP-3]_.
 
 
 Multi-file format
@@ -63,6 +63,7 @@ Single-file format
   
 ``sha1``
   20 bytes. The SHA1 digest calculated over the contents of the file itself, without any additional padding. Can be used to aid file deduplication [#BEP-38]_.
+  The hash should only be considered as a hint, ``pieces`` hashes are the canonical reference for integrity checking.
   
 ``symlink path``
   An array of strings. Path of the symlink target relative to the torrent root directory.
@@ -75,7 +76,7 @@ When the ``l`` attribute flag is present then the ``symlink path`` represents th
   
 The ``length`` field of the symlink file should be zero. A non-zero length identical with the target file would improve backwards-compatibility but significantly complicate the management of piece hashing and duplicate pieces.
   
-The target should be another file within the torrent, otherwise a dangling symlink will be created.
+Just like the regular path the symlink path is relative to the torrent root and must not contain ``..`` elements. It should also target another file within the torrent, otherwise a dangling symlink will be created.
   
   
 Padding files
@@ -98,7 +99,9 @@ The presence of padding files does not imply that all files are piece-aligned.
 Internally inconsistent torrents
 ================================
 
-If used incorrectly or maliciously symlinks and padding files can result in internally inconsistent torrents which cannot finish downloading because they contain conflicting hash information. Similarly the ``sha1`` fields may in fact be inconsistent with the piece data and lead to failures after deduplication.
+If used incorrectly or maliciously symlinks and padding files can result in internally inconsistent torrents which cannot finish downloading because they contain conflicting hash information.
+
+Similarly the ``sha1`` fields may be inconsistent with the piece data and lead to failures after deduplication.
 
 Clients should ensure that adding and deduplicating such a torrent does not lead to loss of already existing data. 
 


### PR DESCRIPTION
Attempting to document libtorrent behavior since the padding part is of interest for feeds and updatable torrents.

But I'm unsure whether it should be 0-sized or reflect the symlink target.