### PR TITLE
bep 0048: Scrape: initial draft

### DIFF
--- a/beps/Makefile
+++ b/beps/Makefile
@@ -51,6 +51,7 @@ BEPS= \
 	bep_0045.html \
 	bep_0046.html \
 	bep_0047.html \
+	bep_0048.html \
 	bep_1000.html \
 
 all:	$(BEPS)

--- a/beps/bep_0048.html
+++ b/beps/bep_0048.html
@@ -60,7 +60,7 @@
 <p>The original BitTorrent Protocol Specification (BEP 003) <a class="footnote-reference" href="#bep-003" id="id1">[1]</a> defines one exchange between a client and a tracker referred to as an Announce.
 In order to build responsive user interfaces, clients desired an additional way to query metadata about Swarms in bulk.
 The exchange that fetches this metadata for the clients is referred to as a Scrape.
-It should be noted that Scrape exchanges have no effect on a peer's participating in a Swarm.</p>
+It should be noted that Scrape exchanges have no effect on a peer's participation in a Swarm.</p>
 </div>
 <div class="section" id="implementation">
 <h1>Implementation</h1>

--- a/beps/bep_0048.html
+++ b/beps/bep_0048.html
@@ -38,8 +38,8 @@
 <tr class="field"><th class="docinfo-name">Title:</th><td class="field-body">Tracker Protocol Extension: Scrape</td>
 </tr>
 <tr><th class="docinfo-name">Version:</th>
-<td>fc9e3530b196bc58a0df77d63e10b7b5e277bcb5</td></tr>
-<tr class="field"><th class="docinfo-name">Last-Modified:</th><td class="field-body">Tue Sep 13 20:06:01 2016 -0400</td>
+<td>676afdae9a36f305bca94cd9b5f88ae5b4e5b78b</td></tr>
+<tr class="field"><th class="docinfo-name">Last-Modified:</th><td class="field-body">Fri Sep 16 20:00:44 2016 -0400</td>
 </tr>
 <tr><th class="docinfo-name">Author:</th>
 <td>Jimmy Zelinskie &lt;<a class="reference external" href="mailto:jimmyzelinskie&#37;&#52;&#48;gmail&#46;com">jimmyzelinskie<span>&#64;</span>gmail<span>&#46;</span>com</a>&gt;</td></tr>
@@ -57,51 +57,56 @@
 </table>
 <div class="section" id="abstract">
 <h1>Abstract</h1>
-<p>The original BitTorrent Protocol Specification (BEP 003) <a class="footnote-reference" href="#bep-003" id="id1">[1]</a> defines an exchange between a client and a tracker referred to as an Announce.
-An Announce has two objectives: update a peer's presence in the Swarm and discover other peers in the Swarm.
-As a result of dealing with multiple objectives, this exchange is computationally expensive when exercised at scale.
-In order to prevent trackers from becoming overloaded, Announces are specified to be sent on an interval dictated by the tracker's Announce response or when a client event occurs.
-However, in order to build responsive user interfaces, clients desired a way to query metadata about Swarms in bulk in the least computationally expensive way.
-The exchange that fetches this metadata for the clients is referred to as a Scrape.</p>
+<p>The original BitTorrent Protocol Specification (BEP 003) <a class="footnote-reference" href="#bep-003" id="id1">[1]</a> defines one exchange between a client and a tracker referred to as an Announce.
+In order to build responsive user interfaces, clients desired an additional way to query metadata about Swarms in bulk.
+The exchange that fetches this metadata for the clients is referred to as a Scrape.
+It should be noted that Scrape exchanges have no effect on a peer's participating in a Swarm.</p>
 </div>
 <div class="section" id="implementation">
 <h1>Implementation</h1>
 <p>As the UDP Tracker Protocol Specification (BEP 015) <a class="footnote-reference" href="#bep-015" id="id2">[2]</a> already defines the implementation of Scrape using the UDP protocol, the following will document the implementation for the HTTP Protocol.</p>
-<div class="section" id="changes-to-announce">
-<h2>Changes to Announce</h2>
-<p>The URL at which the Announce endpoint lives is now expected to contain the word <tt class="docutils literal">announce</tt> somewhere on its path.
-This has been modified so that clients can rewrite this section of the path to <tt class="docutils literal">scrape</tt> in order to determine the endpoint for Scrape requests.
-The standard URL query parameters defined in BEP 003 <a class="footnote-reference" href="#bep-003" id="id3">[1]</a> still follow.
-There are no changes to Announce responses.</p>
-</div>
 <div class="section" id="scrape-request">
 <h2>Scrape Request</h2>
-<p>As per the previous section, clients should rewrite the portion of the Announce URL path containing the word <tt class="docutils literal">announce</tt> to <tt class="docutils literal">scrape</tt> in order to determine the endpoint to send Scrape requests.
-A scrape request contains only one key, the <tt class="docutils literal">info_hash</tt> key specified in BEP 003 <a class="footnote-reference" href="#bep-003" id="id4">[1]</a>, that can be appended multiple times to the subsequent URL via HTTP query parameters:</p>
+<p>In order for a client to create a Scrape request, it must first determine the HTTP URL for the Scrape endpoint.
+This is done by locating the string <tt class="docutils literal">announce</tt> in the Path section <a class="footnote-reference" href="#url-syntax" id="id3">[3]</a> of the Announce URL and replacing it with the string <tt class="docutils literal">scrape</tt>.
+Performing a Scrape request to URLs that are not determined by this method are outside of the scope of this specification.</p>
+<p>A Scrape request contains no HTTP Body, but instead uses HTTP Query Parameters <a class="footnote-reference" href="#url-syntax" id="id4">[3]</a> to encode its key-value pairs.
+There is only one key, the <tt class="docutils literal">info_hash</tt> key specified in BEP 003 <a class="footnote-reference" href="#bep-003" id="id5">[1]</a>.
+This key can be appended multiple times with different values for collecting data about multiple Swarms in one request.</p>
 </div>
 <div class="section" id="scrape-response">
 <h2>Scrape Response</h2>
-<p>A successful response is a bencoded dictionary containing one key-value pair: <tt class="docutils literal">file</tt> paired with a dictionary of Swarm metadata.
-This dictionary is keyed by infohash and yet another dictionary with the keys &quot;complete&quot;, &quot;incomplete&quot;, and &quot;downloaded&quot;.
-The values of these keys are integers with the number of active peers that have completed downloading, the number of active peers that have not completed downloading, and the number of peers that have ever completed downloading.
-An unsuccessful response is the standard bencoded dictionary with a key &quot;failure_reason&quot; and a string value as described in BEP 003 <a class="footnote-reference" href="#bep-003" id="id5">[1]</a>.</p>
+<p>The response to a successful request is a bencoded dictionary containing one key-value pair: the key <tt class="docutils literal">files</tt> with the value being a dictionary of the 20-byte string representation of an infohash paired with a dictionary of Swarm metadata.
+The fields found in the Swarm metadata dictionary are as follows:</p>
+<dl class="docutils">
+<dt>complete</dt>
+<dd>The number of active peers that have completed downloading.</dd>
+<dt>incomplete</dt>
+<dd>The number of active peers that have not completed downloading.</dd>
+<dt>downloaded</dt>
+<dd>The number of peers that have ever completed downloading.</dd>
+</dl>
+<p>The response to an unsuccessful request is a bencoded dictionary with the key <tt class="docutils literal">failure_reason</tt> and a string value as described in BEP 003 <a class="footnote-reference" href="#bep-003" id="id6">[1]</a>.</p>
 </div>
 <div class="section" id="example">
 <h2>Example</h2>
 <p>Request:</p>
 <pre class="literal-block">
-http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&amp;info_hash=yyyyyyyyyyyyyyyyyyyy&amp;info_hash=zzzzzzzzzzzzzzzzzzzz
+http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&amp;info_hash=yyyyyyyyyyyyyyyyyyyy
 </pre>
 <p>Response:</p>
 <pre class="literal-block">
-d
-  5:files
-  d
-    20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
-    20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20e
-    20:zzzzzzzzzzzzzzzzzzzzd8:completei14e10:downloadedi12191e10:incompletei9e
-  e
-e
+d5:filesd20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
+20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20eee
+</pre>
+<p>Response (JSON encoded for readability):</p>
+<pre class="literal-block">
+{
+  'files': {
+    'xxxxxxxxxxxxxxxxxxxx': {'complete': 11, 'downloaded': 13772, 'incomplete': 19},
+    'yyyyyyyyyyyyyyyyyyyy': {'complete': 21, 'downloaded': 206, 'incomplete': 20}
+  }
+}
 </pre>
 </div>
 </div>
@@ -110,7 +115,7 @@ e
 <table class="docutils footnote" frame="void" id="bep-003" rules="none">
 <colgroup><col class="label" /><col /></colgroup>
 <tbody valign="top">
-<tr><td class="label">[1]</td><td><em>(<a class="fn-backref" href="#id1">1</a>, <a class="fn-backref" href="#id3">2</a>, <a class="fn-backref" href="#id4">3</a>, <a class="fn-backref" href="#id5">4</a>)</em> BEP 0003. The BitTorrent Protocol Specification.
+<tr><td class="label">[1]</td><td><em>(<a class="fn-backref" href="#id1">1</a>, <a class="fn-backref" href="#id5">2</a>, <a class="fn-backref" href="#id6">3</a>)</em> BEP 0003. The BitTorrent Protocol Specification.
 (<a class="reference external" href="http://www.bittorrent.org/beps/bep_0003.html">http://www.bittorrent.org/beps/bep_0003.html</a>)</td></tr>
 </tbody>
 </table>
@@ -119,6 +124,13 @@ e
 <tbody valign="top">
 <tr><td class="label"><a class="fn-backref" href="#id2">[2]</a></td><td>BEP 0015. UDP Tracker Protocol for BitTorrent.
 (<a class="reference external" href="http://www.bittorrent.org/beps/bep_0015.html">http://www.bittorrent.org/beps/bep_0015.html</a>)</td></tr>
+</tbody>
+</table>
+<table class="docutils footnote" frame="void" id="url-syntax" rules="none">
+<colgroup><col class="label" /><col /></colgroup>
+<tbody valign="top">
+<tr><td class="label">[3]</td><td><em>(<a class="fn-backref" href="#id3">1</a>, <a class="fn-backref" href="#id4">2</a>)</em> URL Syntax. Wikipedia.
+(<a class="reference external" href="https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax">https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax</a>)</td></tr>
 </tbody>
 </table>
 </div>

--- a/beps/bep_0048.html
+++ b/beps/bep_0048.html
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="Docutils 0.12: http://docutils.sourceforge.net/" />
+<title></title>
+<meta name="author" content="Jimmy Zelinskie &lt;jimmyzelinskie&#64;gmail.com&gt;" />
+<link rel="stylesheet" href="../css/bep.css" type="text/css" />
+</head>
+<body>
+<div class="document">
+
+<div id="upper" class="clear">
+<div id="wrap">
+<div id="header">
+<h1><a href="../index.html">BitTorrent<span>.org</span></a></h1>
+</div>
+<div id="nav">
+<ul>
+<li><a href="../index.html">Home</a></li>
+<li><a href="../introduction.html">For Users</a></li>
+<li><a href="bep_0000.html"><span>For Developers</span></a></li>
+<li><a href="../mailing_list.html">Developer mailing list</a> </li>
+<li><a href="http://forum.bittorrent.org"> Forums (archive) </a></li>
+</ul>
+</div> <!-- nav -->
+<!-- ### Begin Content ### -->
+<div id="second">
+
+
+<table class="docinfo" frame="void" rules="none">
+<col class="docinfo-name" />
+<col class="docinfo-content" />
+<tbody valign="top">
+<tr class="field"><th class="docinfo-name">BEP:</th><td class="field-body">48</td>
+</tr>
+<tr class="field"><th class="docinfo-name">Title:</th><td class="field-body">Tracker Protocol Extension: Scrape</td>
+</tr>
+<tr><th class="docinfo-name">Version:</th>
+<td>fc9e3530b196bc58a0df77d63e10b7b5e277bcb5</td></tr>
+<tr class="field"><th class="docinfo-name">Last-Modified:</th><td class="field-body">Tue Sep 13 20:06:01 2016 -0400</td>
+</tr>
+<tr><th class="docinfo-name">Author:</th>
+<td>Jimmy Zelinskie &lt;<a class="reference external" href="mailto:jimmyzelinskie&#37;&#52;&#48;gmail&#46;com">jimmyzelinskie<span>&#64;</span>gmail<span>&#46;</span>com</a>&gt;</td></tr>
+<tr><th class="docinfo-name">Status:</th>
+<td>Draft</td></tr>
+<tr class="field"><th class="docinfo-name">Type:</th><td class="field-body">Standards Track</td>
+</tr>
+<tr class="field"><th class="docinfo-name">Content-Type:</th><td class="field-body">text/x-rst</td>
+</tr>
+<tr class="field"><th class="docinfo-name">Created:</th><td class="field-body">08-Sep-2016</td>
+</tr>
+<tr class="field"><th class="docinfo-name">Post-History:</th><td class="field-body"></td>
+</tr>
+</tbody>
+</table>
+<div class="section" id="abstract">
+<h1>Abstract</h1>
+<p>The original BitTorrent Protocol Specification (BEP 003) <a class="footnote-reference" href="#bep-003" id="id1">[1]</a> defines an exchange between a client and a tracker referred to as an Announce.
+An Announce has two objectives: update a peer's presence in the Swarm and discover other peers in the Swarm.
+As a result of dealing with multiple objectives, this exchange is computationally expensive when exercised at scale.
+In order to prevent trackers from becoming overloaded, Announces are specified to be sent on an interval dictated by the tracker's Announce response or when a client event occurs.
+However, in order to build responsive user interfaces, clients desired a way to query metadata about Swarms in bulk in the least computationally expensive way.
+The exchange that fetches this metadata for the clients is referred to as a Scrape.</p>
+</div>
+<div class="section" id="implementation">
+<h1>Implementation</h1>
+<p>As the UDP Tracker Protocol Specification (BEP 015) <a class="footnote-reference" href="#bep-015" id="id2">[2]</a> already defines the implementation of Scrape using the UDP protocol, the following will document the implementation for the HTTP Protocol.</p>
+<div class="section" id="changes-to-announce">
+<h2>Changes to Announce</h2>
+<p>The URL at which the Announce endpoint lives is now expected to contain the word <tt class="docutils literal">announce</tt> somewhere on its path.
+This has been modified so that clients can rewrite this section of the path to <tt class="docutils literal">scrape</tt> in order to determine the endpoint for Scrape requests.
+The standard URL query parameters defined in BEP 003 <a class="footnote-reference" href="#bep-003" id="id3">[1]</a> still follow.
+There are no changes to Announce responses.</p>
+</div>
+<div class="section" id="scrape-request">
+<h2>Scrape Request</h2>
+<p>As per the previous section, clients should rewrite the portion of the Announce URL path containing the word <tt class="docutils literal">announce</tt> to <tt class="docutils literal">scrape</tt> in order to determine the endpoint to send Scrape requests.
+A scrape request contains only one key, the <tt class="docutils literal">info_hash</tt> key specified in BEP 003 <a class="footnote-reference" href="#bep-003" id="id4">[1]</a>, that can be appended multiple times to the subsequent URL via HTTP query parameters:</p>
+</div>
+<div class="section" id="scrape-response">
+<h2>Scrape Response</h2>
+<p>A successful response is a bencoded dictionary containing one key-value pair: <tt class="docutils literal">file</tt> paired with a dictionary of Swarm metadata.
+This dictionary is keyed by infohash and yet another dictionary with the keys &quot;complete&quot;, &quot;incomplete&quot;, and &quot;downloaded&quot;.
+The values of these keys are integers with the number of active peers that have completed downloading, the number of active peers that have not completed downloading, and the number of peers that have ever completed downloading.
+An unsuccessful response is the standard bencoded dictionary with a key &quot;failure_reason&quot; and a string value as described in BEP 003 <a class="footnote-reference" href="#bep-003" id="id5">[1]</a>.</p>
+</div>
+<div class="section" id="example">
+<h2>Example</h2>
+<p>Request:</p>
+<pre class="literal-block">
+http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&amp;info_hash=yyyyyyyyyyyyyyyyyyyy&amp;info_hash=zzzzzzzzzzzzzzzzzzzz
+</pre>
+<p>Response:</p>
+<pre class="literal-block">
+d
+  5:files
+  d
+    20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
+    20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20e
+    20:zzzzzzzzzzzzzzzzzzzzd8:completei14e10:downloadedi12191e10:incompletei9e
+  e
+e
+</pre>
+</div>
+</div>
+<div class="section" id="references">
+<h1>References</h1>
+<table class="docutils footnote" frame="void" id="bep-003" rules="none">
+<colgroup><col class="label" /><col /></colgroup>
+<tbody valign="top">
+<tr><td class="label">[1]</td><td><em>(<a class="fn-backref" href="#id1">1</a>, <a class="fn-backref" href="#id3">2</a>, <a class="fn-backref" href="#id4">3</a>, <a class="fn-backref" href="#id5">4</a>)</em> BEP 0003. The BitTorrent Protocol Specification.
+(<a class="reference external" href="http://www.bittorrent.org/beps/bep_0003.html">http://www.bittorrent.org/beps/bep_0003.html</a>)</td></tr>
+</tbody>
+</table>
+<table class="docutils footnote" frame="void" id="bep-015" rules="none">
+<colgroup><col class="label" /><col /></colgroup>
+<tbody valign="top">
+<tr><td class="label"><a class="fn-backref" href="#id2">[2]</a></td><td>BEP 0015. UDP Tracker Protocol for BitTorrent.
+(<a class="reference external" href="http://www.bittorrent.org/beps/bep_0015.html">http://www.bittorrent.org/beps/bep_0015.html</a>)</td></tr>
+</tbody>
+</table>
+</div>
+
+</div>
+	<div id="footer">
+<hr/>
+</div>
+
+</div>
+</body>
+</html>

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -24,19 +24,16 @@ Implementation
 
 As the UDP Tracker Protocol Specification (BEP 015) [#BEP_015]_ already defines the implementation of Scrape using the UDP protocol, the following will document the implementation for the HTTP Protocol.
 
-Changes to Announce
-...................
-
-The URL at which the Announce endpoint lives is now expected to contain the word ``announce`` somewhere on its path.
-This has been modified so that clients can rewrite this section of the path to ``scrape`` in order to determine the endpoint for Scrape requests.
-The standard URL query parameters defined in BEP 003 [#BEP_003]_ still follow.
-There are no changes to Announce responses.
-
 Scrape Request
 ..............
 
-As per the previous section, clients should rewrite the portion of the Announce URL path containing the word ``announce`` to ``scrape`` in order to determine the endpoint to send Scrape requests.
-A scrape request contains only one key, the ``info_hash`` key specified in BEP 003 [#BEP_003]_, that can be appended multiple times to the subsequent URL via HTTP query parameters:
+In order for a client to create a Scrape request, it must first determine the HTTP URL for the Scrape endpoint.
+This is done by locating the string ``announce`` in the Path section [#URL_Syntax]_ of the Announce URL and replacing it with the string ``scrape``.
+Performing a Scrape request to URLs that are not determined by this method are outside of the scope of this specification.
+
+A Scrape request contains no HTTP Body, but instead uses HTTP Query Parameters [#URL_Syntax]_ to encode its key-value pairs.
+There is only one key, the ``info_hash`` key specified in BEP 003 [#BEP_003]_.
+This key can be appended multiple times with different values for collecting data about multiple Swarms in one request.
 
 Scrape Response
 ...............

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -38,11 +38,19 @@ This key can be appended multiple times with different values for collecting dat
 Scrape Response
 ...............
 
-A successful response is a bencoded dictionary containing one key-value pair: ``file`` paired with a dictionary of Swarm metadata.
-This dictionary is keyed by infohash and yet another dictionary with the keys "complete", "incomplete", and "downloaded".
-The values of these keys are integers with the number of active peers that have completed downloading, the number of active peers that have not completed downloading, and the number of peers that have ever completed downloading.
-An unsuccessful response is the standard bencoded dictionary with a key "failure_reason" and a string value as described in BEP 003 [#BEP_003]_.
+The response to a successful request is a bencoded dictionary containing one key-value pair: the key ``files`` with the value being a dictionary of the 20-byte string representation of an infohash paired with a dictionary of Swarm metadata.
+The fields found in the Swarm metadata dictionary are as follows:
 
+complete
+  The number of active peers that have completed downloading.
+
+incomplete
+  The number of active peers that have not completed downloading.
+
+downloaded
+  The number of peers that have ever completed downloading.
+
+The response to an unsuccessful request is a bencoded dictionary with the key ``failure_reason`` and a string value as described in BEP 003 [#BEP_003]_.
 
 Example
 ........

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -13,12 +13,10 @@
 Abstract
 --------
 
-The original BitTorrent Protocol Specification (BEP 003) [#BEP_003]_ defines an exchange between a client and a tracker referred to as an Announce.
-An Announce has two objectives: update a peer's presence in the Swarm and discover other peers in the Swarm.
-As a result of dealing with multiple objectives, this exchange is computationally expensive when exercised at scale.
-In order to prevent trackers from becoming overloaded, Announces are specified to be sent on an interval dictated by the tracker's Announce response or when a client event occurs.
-However, in order to build responsive user interfaces, clients desired a way to query metadata about Swarms in bulk in the least computationally expensive way.
+The original BitTorrent Protocol Specification (BEP 003) [#BEP_003]_ defines one exchange between a client and a tracker referred to as an Announce.
+In order to build responsive user interfaces, clients desired an additional way to query metadata about Swarms in bulk.
 The exchange that fetches this metadata for the clients is referred to as a Scrape.
+It should be noted that Scrape exchanges have no effect on a peer's participating in a Swarm.
 
 
 Implementation

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -1,0 +1,81 @@
+:BEP: 48
+:Title: Tracker Protocol Extension: Scrape
+:Version: $Revision$
+:Last-Modified: $Date$
+:Author:  Jimmy Zelinskie <jimmyzelinskie@gmail.com>
+:Status:  Draft
+:Type:    Standards Track
+:Content-Type: text/x-rst
+:Created: 08-Sep-2016
+:Post-History:
+
+
+Abstract
+--------
+
+The original BitTorrent Protocol Specification (BEP 003) [#BEP_003]_ defines an exchange between a client and a tracker referred to as an Announce.
+An Announce has two objectives: update a peer's presence in the Swarm and discover other peers in the Swarm.
+As a result of dealing with multiple objectives, this exchange is computationally expensive when exercised at scale.
+In order to prevent trackers from becoming overloaded, Announces are specified to be sent on an interval dictated by the tracker's Announce response or when a client event occurs.
+However, in order to build responsive user interfaces, clients desired a way to query metadata about Swarms in bulk in the least computationally expensive way.
+The exchange that fetches this metadata for the clients is referred to as a Scrape.
+
+
+Implementation
+--------------
+
+As the UDP Tracker Protocol Specification (BEP 015) [#BEP_015]_ already defines the implementation of Scrape using the UDP protocol, the following will document the implementation for the HTTP Protocol.
+
+Changes to Announce
+...................
+
+The URL at which the Announce endpoint lives is now expected to contain the word ``announce`` somewhere on its path.
+This has been modified so that clients can rewrite this section of the path to ``scrape`` in order to determine the endpoint for Scrape requests.
+The standard URL query parameters defined in BEP 003 [#BEP_003]_ still follow.
+There are no changes to Announce responses.
+
+Scrape Request
+..............
+
+As per the previous section, clients should rewrite the portion of the Announce URL path containing the word ``announce`` to ``scrape`` in order to determine the endpoint to send Scrape requests.
+A scrape request contains only one key, the ``info_hash`` key specified in BEP 003 [#BEP_003]_, that can be appended multiple times to the subsequent URL via HTTP query parameters:
+
+Scrape Response
+...............
+
+A successful response is a bencoded dictionary containing one key-value pair: ``file`` paired with a dictionary of Swarm metadata.
+This dictionary is keyed by infohash and yet another dictionary with the keys "complete", "incomplete", and "downloaded".
+The values of these keys are integers with the number of active peers that have completed downloading, the number of active peers that have not completed downloading, and the number of peers that have ever completed downloading.
+An unsuccessful response is the standard bencoded dictionary with a key "failure_reason" and a string value as described in BEP 003 [#BEP_003]_.
+
+
+Example
+........
+
+Request:
+
+::
+
+  http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&info_hash=yyyyyyyyyyyyyyyyyyyy&info_hash=zzzzzzzzzzzzzzzzzzzz
+
+Response:
+
+::
+
+  d
+    5:files
+    d
+      20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
+      20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20e
+      20:zzzzzzzzzzzzzzzzzzzzd8:completei14e10:downloadedi12191e10:incompletei9e
+    e
+  e
+
+References
+----------
+
+.. [#BEP_003] BEP 0003. The BitTorrent Protocol Specification.
+   (http://www.bittorrent.org/beps/bep_0003.html)
+
+.. [#BEP_015] BEP 0015. UDP Tracker Protocol for BitTorrent.
+   (http://www.bittorrent.org/beps/bep_0015.html)

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -88,3 +88,6 @@ References
 
 .. [#BEP_015] BEP 0015. UDP Tracker Protocol for BitTorrent.
    (http://www.bittorrent.org/beps/bep_0015.html)
+
+.. [#URL_Syntax] URL Syntax. Wikipedia.
+   (https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax)

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -59,20 +59,26 @@ Request:
 
 ::
 
-  http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&info_hash=yyyyyyyyyyyyyyyyyyyy&info_hash=zzzzzzzzzzzzzzzzzzzz
+  http://tracker/scrape?info_hash=xxxxxxxxxxxxxxxxxxxx&info_hash=yyyyyyyyyyyyyyyyyyyy
 
 Response:
 
 ::
 
-  d
-    5:files
-    d
-      20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
-      20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20e
-      20:zzzzzzzzzzzzzzzzzzzzd8:completei14e10:downloadedi12191e10:incompletei9e
-    e
-  e
+  d5:filesd20:xxxxxxxxxxxxxxxxxxxxd8:completei11e10:downloadedi13772e10:incompletei19e
+  20:yyyyyyyyyyyyyyyyyyyyd8:completei21e10:downloadedi206e10:incompletei20eee
+
+Response (JSON encoded for readability):
+
+::
+
+  {
+    'files': {
+      'xxxxxxxxxxxxxxxxxxxx': {'complete': 11, 'downloaded': 13772, 'incomplete': 19},
+      'yyyyyyyyyyyyyyyyyyyy': {'complete': 21, 'downloaded': 206, 'incomplete': 20}
+    }
+  }
+
 
 References
 ----------

--- a/beps/bep_0048.rst
+++ b/beps/bep_0048.rst
@@ -16,7 +16,7 @@ Abstract
 The original BitTorrent Protocol Specification (BEP 003) [#BEP_003]_ defines one exchange between a client and a tracker referred to as an Announce.
 In order to build responsive user interfaces, clients desired an additional way to query metadata about Swarms in bulk.
 The exchange that fetches this metadata for the clients is referred to as a Scrape.
-It should be noted that Scrape exchanges have no effect on a peer's participating in a Swarm.
+It should be noted that Scrape exchanges have no effect on a peer's participation in a Swarm.
 
 
 Implementation


### PR DESCRIPTION
As per the discussion in #42, this BEP describing a tracker scrape in general and lays out its implementation in HTTP.

I feel like I should credit someone else for the initial idea -- I think Azureus was the first client to implement support.

Looking for feedback! Thanks