### PR TITLE
bep06: remove misleading '*' in allowed fast message description

### DIFF
--- a/beps/bep_0006.rst
+++ b/beps/bep_0006.rst
@@ -134,7 +134,7 @@ Allowed Fast
 
 ::
 
-* Allowed Fast: <len=0x0005><op=0x11><index>*
+*Allowed Fast*: <len=0x0005><op=0x11><index>
 
 With the BitTorrent protocol specified in `BEP 0003`_, new peers take
 several minutes to ramp up before they can effectively engage in


### PR DESCRIPTION
the `<index>*` could wrongly be interpreted as list of indexes
(which would make more sense than sending k separate allowed fast messages)