### PR TITLE
improve link visibility in BEP bodies

### DIFF
--- a/css/bep.css
+++ b/css/bep.css
@@ -270,11 +270,21 @@ a {
 	color:#345;
 	text-decoration:none;
 	border-bottom:1px solid #eee; 
-	}
+}
+	
+#second a {
+	color:#07c;
+	border-bottom: 1px dotted #07c;  
+}
+
+#second a:visited {
+	color:#678;
+	border-bottom-color: #678;
+}
 
 a:visited {
-	color:#678;	
-	}
+	color:#678;
+}
 
 #nav a:visited {
     color:#345; 


### PR DESCRIPTION
I noticed that the `here` link in a [BEP52 section](http://bittorrent.org/beps/bep_0052.html#metainfo-files) has pretty low visibility, this might improve things a bit.