### PR TITLE
[BEP 5] Add IPv6 Address to metainfo `nodes` example

### DIFF
--- a/beps/bep_0005.html
+++ b/beps/bep_0005.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.15.2: http://docutils.sourceforge.net/" />
 <title>bep_0005.rst_post</title>
 <meta name="author" content="Andrew Loewenstern &lt;drue&#64;bittorrent.com&gt;, Arvid Norberg &lt;arvid&#64;bittorrent.com&gt;" />
 <link rel="stylesheet" href="../css/bep.css" type="text/css" />
@@ -38,8 +38,8 @@
 <tr class="title field"><th class="docinfo-name">Title:</th><td class="field-body">DHT Protocol</td>
 </tr>
 <tr><th class="docinfo-name">Version:</th>
-<td>d7976ebbd42e46e3a14a5b7fa50b1cc89a7c568d</td></tr>
-<tr class="last-modified field"><th class="docinfo-name">Last-Modified:</th><td class="field-body">Sat Sep 16 21:41:39 2017 -0600</td>
+<td>aa944d9e2faf989cbb4b1bad5ec130b9f22631d9</td></tr>
+<tr class="last-modified field"><th class="docinfo-name">Last-Modified:</th><td class="field-body">Tue Jan 21 15:59:05 2020 -0800</td>
 </tr>
 <tr><th class="docinfo-name">Author:</th>
 <td>Andrew Loewenstern &lt;<a class="reference external" href="mailto:drue&#37;&#52;&#48;bittorrent&#46;com">drue<span>&#64;</span>bittorrent<span>&#46;</span>com</a>&gt;, Arvid Norberg &lt;<a class="reference external" href="mailto:arvid&#37;&#52;&#48;bittorrent&#46;com">arvid<span>&#64;</span>bittorrent<span>&#46;</span>com</a>&gt;</td></tr>
@@ -197,7 +197,7 @@ automatically add &quot;router.bittorrent.com&quot; to torrent files or
 automatically add this node to clients routing tables.</p>
 <pre class="literal-block">
 nodes = [[&quot;&lt;host&gt;&quot;, &lt;port&gt;], [&quot;&lt;host&gt;&quot;, &lt;port&gt;], ...]
-nodes = [[&quot;127.0.0.1&quot;, 6881], [&quot;your.router.node&quot;, 4804]]
+nodes = [[&quot;127.0.0.1&quot;, 6881], [&quot;your.router.node&quot;, 4804], [&quot;2001:db8:100:0:d5c8:db3f:995e:c0f7&quot;, 1941]]
 </pre>
 </div>
 <div class="section" id="krpc-protocol">

--- a/beps/bep_0005.rst
+++ b/beps/bep_0005.rst
@@ -173,7 +173,7 @@ automatically add this node to clients routing tables.
 ::
 
   nodes = [["<host>", <port>], ["<host>", <port>], ...]
-  nodes = [["127.0.0.1", 6881], ["your.router.node", 4804]]
+  nodes = [["127.0.0.1", 6881], ["your.router.node", 4804], ["2001:db8:100:0:d5c8:db3f:995e:c0f7", 1941]]
 
   
 


### PR DESCRIPTION
Adds an IPv6 address to the BEP 5 metainfo `nodes` key example. Fixes #103.

I also regenerated the HTML according to the instructions in `beps/README.txt` and `beps/Makefile`.