### PR TITLE
BEP-56: Data compression extension

### DIFF
--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -1,5 +1,5 @@
 :BEP: 56
-:Title: Extension for Peers to Send Metadata Files
+:Title: Data compression extension
 :Version: $Revision$
 :Last-Modified: $Date$
 :Author:  Alexander Ivanov <saiv46@yandex.ru>
@@ -10,49 +10,45 @@
 
 Abstract
 ========
-This extension adds a capability for clients to enable compression of
-data streams, effectively improving bandwidth for clients supporting it.
+This extension adds a capability for clients to negotiate and use
+compression methods for data streams or torrent pieces, effectively
+improving bandwidth for supporting clients.
 
 Rationale
 =========
 This extension would allow clients to download files faster, without
-using file archivers. Since large files are often precompressed before
+using file archivers. Since large files are often pre-compressed before
 torrent creation, downloaders needs to keep both the archives
-(for seeding) and uncompresed files (for own usage).
+(for seeding) and uncompressed files (for own usage).
 
 Most users prefer to remove such torrents, thus harming proper file
-distribution. For example: Organizations using bittorrent for software
+distribution. For example: Organizations using Bittorrent for software
 distribution needs to have centralized storage for new customers, no
-matter how many customers already have same software.
+matter how many customers have the same software already.
 
 Extension header
 ================
 
 This extension uses the extension protocol (specified in `BEP 0010`_)
-to advertize client capability of using chunk compression. It defines
+to advertise client capability of using chunk compression. It defines
 following items in the extension protocol handshake message:
 +-------+-----------------------------------------------------------+
 | name  | description                                               |
 +=======+===========================================================+
-| c     | Dictionary of supported compression algorithm which maps  |
+| c     | Dictionary of supported compression algorithms which maps |
 |       | its identifiers to its priority (unsigned 8-bit integer), |
 |       | clients can adjust it based on compression speed/ratio,   |
-|       | hardware support, performance and power mode, et cetera.  |
+|       | hardware support, performance, and power mode et cetera.  |
 |       | Priority set to zero means that the compression algorithm |
-|       | is not supported or disabled by user, The client should   |
-|       | ignore any algorithms it doesn't recognize/malformed.     |
-+-------+-----------------------------------------------------------+
-| cp    | Optional field with prefered compression algorithm.       |
-|       | If client supports that algorithm and it's not disabled,  |
-|       | then it must expect to recieve pieces compressed by that  |
-|       | specified algorithm.                                      |
+|       | is not supported or disabled by user, the client must     |
+|       | ignore unknown algorithms.                                |
 +-------+-----------------------------------------------------------+
 
 
 
-Compression algorithm is selected by taking dictionary item with highest
-priority from intersection of items supported by both peers, if there
-isn't any suitable compression algorithm - compression will be disabled.
+The compression algorithm is selected by taking the dictionary item with
+highest priority from intersection of items supported by both peers,
+if there isn't any suitable compression algorithm - compression will be disabled.
 
 Example of extension handshake message:
 
@@ -84,9 +80,11 @@ sending, client can specify ``cp`` field during handshake.
 Allowed compression algorithms
 ------------------------------
 
-Compression algorithms must satisfy following requirements:
+Compression algorithms must satisfy the following requirements:
 
-1. Decompression speed must not be lower than 500MB/s.
+1. Decompression speed must not be lower than 500 MB/s.
+
+2. It must not produce a larger piece than the original by 1%.
 
 2. It must not produce larger piece than original by 1%.
 

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -97,31 +97,17 @@ Compression algorithms must satisfy the following requirements:
 
 2. It must not produce a larger piece than the original by 1%.
 
-For consistency, identifiers are prefixed by ``p_`` or ``s_``
-for "piece" and "stream" compression methods accordingly.
-
 +-------------+-----------------------------+
 | identifier  | compression algorithm       |
 +=============+=============================+
-| p_lz4       | LZ4                         |
+| lz4         | LZ4                         |
 +-------------+-----------------------------+
-| s_lz4       | LZ4                         |
+| density     | Chameleon (DENSITY library) |
 +-------------+-----------------------------+
-| p_density   | Chameleon (DENSITY library) |
-+-------------+-----------------------------+
-| s_density   | Chameleon (DENSITY library) |
-+-------------+-----------------------------+
-| p_zstd      | ZStandard                   |
-+-------------+-----------------------------+
-| s_zstd      | ZStandard                   |
+| zstd        | ZStandard                   |
 +-------------+-----------------------------+
 
-This specification deliberately doesn't provide negotiation
-for configuration options, default ones must be used unless
-specified otherwise.
-
-**NOTE**: Currently, only ``p_zstd`` and ``s_zstd`` algorithms
-are required for implementation.
+**NOTE**: Currently, only ``zstd`` algorithm is required for implementation.
 
 References
 ==========

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -10,9 +10,8 @@
 
 Abstract
 ========
-This extension adds a capability for clients to apply on-the-fly
-compression on seeded pieces (next - chunks), effectively improving
-bandwidth on torrents for clients supporting it.
+This extension adds a capability for clients to enable compression of
+data streams, effectively improving bandwidth for clients supporting it.
 
 Rationale
 =========
@@ -62,24 +61,23 @@ Example of extension handshake message:
     {
 		'c': {
 			'lz4': 21,
-			'density_chameleon': 18,
-			'density_cheetah': 13,
-			'density_lion': 9,
-			'zstd': 0
+			'zstd': 16,
+			'density': 7
 		},
-		'cp': 'lz4'
+		'cp': 'zstd'
 	}
 
 
-Piece compression
+Stream compression
 =================
-Some algorithms can't compress unreasonably small pieces efficiently, so
-client should lower algorithm's priority during handshake, depending on
-expected compression ratio for defined piece size (down to zero in worst case).
-After compression algorithm is negotiated, next pieces are sent compressed.
+Compression can't be efficient on pieces less than 4 MB, so whole stream is
+being compressed instead by clients. During handshake, clients should lower
+or raise algorithm's priority depending on expected compression ratio or
+any other factors that could impact compression efficiency and performance.
+After compression algorithm is negotiated, whole stream is being compressed.
 
-If client is caching seeding/recieved pieces in memory, then pieces should
-be stored compressed, decompressing when saving to disk or sending to peer
+If client is caching seeding/recieved pieces in memory, then pieces can be
+stored compressed, decompressing when saving to disk or sending to peer
 which not supports that compression. To avoid re-compression pieces when
 sending, client can specify ``cp`` field during handshake.
 
@@ -88,25 +86,21 @@ Allowed compression algorithms
 
 Compression algorithms must satisfy following requirements:
 
-1. Decompression speed must not be lower than 1000MB/s.
+1. Decompression speed must not be lower than 500MB/s.
 
 2. It must not produce larger piece than original by 1%.
 
-+-------------+-----------------------------------------------------+
-| identifier  | compression algorithm                               |
-+=============+=====================================================+
-| lz4         | LZ4                                                 |
-+-------------+-----------------------------------------------------+
-| lz4_hc      | High compression derivative of LZ4                  |
-+-------------+-----------------------------------------------------+
-| d_chameleon | Chameleon algorithm for DENSITY                     |
-+-------------+-----------------------------------------------------+
-| d_cheetah   | Cheetah algorithm for DENSITY                       |
-+-------------+-----------------------------------------------------+
-| d_lion      | Lion algorithm for DENSITY                          |
-+-------------+-----------------------------------------------------+
++-------------+-----------------------------+
+| identifier  | compression algorithm       |
++=============+=============================+
+| lz4         | LZ4                         |
++-------------+-----------------------------+
+| density     | Chameleon (DENSITY library) |
++-------------+-----------------------------+
+| zstd        | ZStandard                   |
++-------------+-----------------------------+
 
-WARNING: Table is for demonstration purposes only, since this is a draft.
+NOTE: Only ``zstd`` compression required to be implemented to use compression.
 
 References
 ==========

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -2,7 +2,7 @@
 :Title: Data compression extension
 :Version: $Revision$
 :Last-Modified: $Date$
-:Author:  Alexander Ivanov <saiv46@yandex.ru>
+:Author:  Alexander Ivanov <saiv46.dev+bep@gmail.com>
 :Status:  Draft
 :Type:    Standards Track
 :Created: 31-Sep-2021

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -141,14 +141,8 @@ to that ```cresponse``` message, but also can send that message at any
 point of time to disable compression or ask for new request.
 
 
-Allowed compression algorithms
-------------------------------
-
-Compression algorithms must satisfy the following requirements:
-
-1. Decompression speed must not be lower than 500 MB/s.
-
-2. It must not produce a larger piece than the original by 1%.
+Compression algorithm list
+--------------------------
 
 +-------------+-----------------------------+
 | identifier  | compression algorithm       |
@@ -160,7 +154,8 @@ Compression algorithms must satisfy the following requirements:
 | zstd        | ZStandard                   |
 +-------------+-----------------------------+
 
-**NOTE**: Currently, only ``zstd`` algorithm is required for implementation.
+This is a list of known algorithms, to submit a allocation please
+contact author of this specification.
 
 References
 ==========

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -56,26 +56,37 @@ Example of extension handshake message:
 
     {
 		'c': {
-			'lz4': 21,
-			'zstd': 16,
-			'density': 7
-		},
-		'cp': 'zstd'
+			'p_zstd': 255,
+      's_zstd': 153,
+      'p_lz4': 106,
+			'p_density': 70,
+      's_lz4': 41,
+			's_density': 37
+		}
 	}
 
 
-Stream compression
-=================
-Compression can't be efficient on pieces less than 4 MB, so whole stream is
-being compressed instead by clients. During handshake, clients should lower
-or raise algorithm's priority depending on expected compression ratio or
-any other factors that could impact compression efficiency and performance.
-After compression algorithm is negotiated, whole stream is being compressed.
+Compression methods
+===================
+Extension provides two approaches (methods) to compression, which have
+their own trade-offs, so choice between these should be made by clients
+on per-torrent basis, using its metadata (properties like piece size).
 
-If client is caching seeding/recieved pieces in memory, then pieces can be
-stored compressed, decompressing when saving to disk or sending to peer
-which not supports that compression. To avoid re-compression pieces when
-sending, client can specify ``cp`` field during handshake.
+With **by-piece compression** method, client must compress each piece
+individually, which lowers overall compression ratio but result can
+be stored in cache and reused, probably providing more efficiency.
+If the client is caching compressed pieces in memory, then it can be
+decompressed when saving to disk or sending to peer, which not supports
+compression. To reduce piece re-compression, client should raise
+current algorithm's priority during handshake. This method has low
+efficiency with pieces smaller than 4 MB.
+
+Clients using **stream compression** method instead compresses whole
+data stream, so compression ratio should be higher. During handshake,
+clients should lower or raise algorithm's priority depending on expected
+factors that could impact compression efficiency and performance. This
+method can introduce performance issues if used on thousands of
+simultaneous connections.
 
 Allowed compression algorithms
 ------------------------------
@@ -86,19 +97,31 @@ Compression algorithms must satisfy the following requirements:
 
 2. It must not produce a larger piece than the original by 1%.
 
-2. It must not produce larger piece than original by 1%.
+For consistency, identifiers are prefixed by ``p_`` or ``s_``
+for "piece" and "stream" compression methods accordingly.
 
 +-------------+-----------------------------+
 | identifier  | compression algorithm       |
 +=============+=============================+
-| lz4         | LZ4                         |
+| p_lz4       | LZ4                         |
 +-------------+-----------------------------+
-| density     | Chameleon (DENSITY library) |
+| s_lz4       | LZ4                         |
 +-------------+-----------------------------+
-| zstd        | ZStandard                   |
+| p_density   | Chameleon (DENSITY library) |
++-------------+-----------------------------+
+| s_density   | Chameleon (DENSITY library) |
++-------------+-----------------------------+
+| p_zstd      | ZStandard                   |
++-------------+-----------------------------+
+| s_zstd      | ZStandard                   |
 +-------------+-----------------------------+
 
-NOTE: Only ``zstd`` compression required to be implemented to use compression.
+This specification deliberately doesn't provide negotiation
+for configuration options, default ones must be used unless
+specified otherwise.
+
+**NOTE**: Currently, only ``p_zstd`` and ``s_zstd`` algorithms
+are required for implementation.
 
 References
 ==========

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -54,16 +54,16 @@ Example of extension handshake message:
 
 ::
 
-    {
-		'c': {
-			'p_zstd': 255,
+  {
+    'c': {
+      'p_zstd': 255,
       's_zstd': 153,
       'p_lz4': 106,
-			'p_density': 70,
+      'p_density': 70,
       's_lz4': 41,
-			's_density': 37
-		}
-	}
+      's_density': 37
+    }
+  }
 
 
 Compression methods

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -1,0 +1,130 @@
+:BEP: 56
+:Title: Extension for Peers to Send Metadata Files
+:Version: $Revision$
+:Last-Modified: $Date$
+:Author:  Alexander Ivanov <saiv46@yandex.ru>
+:Status:  Draft
+:Type:    Standards Track
+:Created: 31-Sep-2021
+:Post-History: 
+
+Abstract
+========
+This extension adds a capability for clients to apply on-the-fly
+compression on seeded pieces (next - chunks), effectively improving
+bandwidth on torrents for clients supporting it.
+
+Rationale
+=========
+This extension would allow clients to download files faster, without
+using file archivers. Since large files are often precompressed before
+torrent creation, downloaders needs to keep both the archives
+(for seeding) and uncompresed files (for own usage).
+
+Most users prefer to remove such torrents, thus harming proper file
+distribution. For example: Organizations using bittorrent for software
+distribution needs to have centralized storage for new customers, no
+matter how many customers already have same software.
+
+Extension header
+================
+
+This extension uses the extension protocol (specified in `BEP 0010`_)
+to advertize client capability of using chunk compression. It defines
+following items in the extension protocol handshake message:
++-------+-----------------------------------------------------------+
+| name  | description                                               |
++=======+===========================================================+
+| c     | Dictionary of supported compression algorithm which maps  |
+|       | its identifiers to its priority (unsigned 8-bit integer), |
+|       | clients can adjust it based on compression speed/ratio,   |
+|       | hardware support, performance and power mode, et cetera.  |
+|       | Priority set to zero means that the compression algorithm |
+|       | is not supported or disabled by user, The client should   |
+|       | ignore any algorithms it doesn't recognize/malformed.     |
++-------+-----------------------------------------------------------+
+| cp    | Optional field with prefered compression algorithm.       |
+|       | If client supports that algorithm and it's not disabled,  |
+|       | then it must expect to recieve pieces compressed by that  |
+|       | specified algorithm.                                      |
++-------+-----------------------------------------------------------+
+
+
+
+Compression algorithm is selected by taking dictionary item with highest
+priority from intersection of items supported by both peers, if there
+isn't any suitable compression algorithm - compression will be disabled.
+
+Example of extension handshake message:
+
+::
+
+    {
+		'c': {
+			'lz4': 21,
+			'density_chameleon': 18,
+			'density_cheetah': 13,
+			'density_lion': 9,
+			'zstd': 0
+		},
+		'cp': 'lz4'
+	}
+
+
+Piece compression
+=================
+Some algorithms can't compress unreasonably small pieces efficiently, so
+client should lower algorithm's priority during handshake, depending on
+expected compression ratio for defined piece size (down to zero in worst case).
+After compression algorithm is negotiated, next pieces are sent compressed.
+
+If client is caching seeding/recieved pieces in memory, then pieces should
+be stored compressed, decompressing when saving to disk or sending to peer
+which not supports that compression. To avoid re-compression pieces when
+sending, client can specify ``cp`` field during handshake.
+
+Allowed compression algorithms
+------------------------------
+
+Compression algorithms must satisfy following requirements:
+
+1. Decompression speed must not be lower than 1000MB/s.
+
+2. It must not produce larger piece than original by 1%.
+
++-------------+-----------------------------------------------------+
+| identifier  | compression algorithm                               |
++=============+=====================================================+
+| lz4         | LZ4                                                 |
++-------------+-----------------------------------------------------+
+| lz4_hc      | High compression derivative of LZ4                  |
++-------------+-----------------------------------------------------+
+| d_chameleon | Chameleon algorithm for DENSITY                     |
++-------------+-----------------------------------------------------+
+| d_cheetah   | Cheetah algorithm for DENSITY                       |
++-------------+-----------------------------------------------------+
+| d_lion      | Lion algorithm for DENSITY                          |
++-------------+-----------------------------------------------------+
+
+WARNING: Table is for demonstration purposes only, since this is a draft.
+
+References
+==========
+
+.. _`BEP 0010`: http://www.bittorrent.org/beps/bep_0010.html
+
+
+Copyright
+=========
+
+This document has been placed in the public domain.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -140,6 +140,9 @@ but should do that right after handshake. Responding client must respond
 to that ```cresponse``` message, but also can send that message at any
 point of time to disable compression or ask for new request.
 
+If using stream mode compression, everything past ```crequest``` message
+is (un)compressed by algorithm specified in that message.
+
 
 Compression algorithm list
 --------------------------

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -47,6 +47,27 @@ factors that could impact compression efficiency and performance. This
 method can introduce performance issues if used on thousands of
 simultaneous connections.
 
+
+Protocol Extension
+==================
+
+This extension uses the extension protocol [#BEP-10]_ to advertise
+client capability regarding compression, as well as introducing a
+new messages in the extension handshake:
+
+.. parsed-literal::
+
+    {
+      m: {
+        crequest: *<implementation-dependent message ID>*,
+        cresponse: *<implementation-dependent message ID>*,
+        cpiece: *<implementation-dependent message ID>*,
+        ...
+      },
+      ...
+    } 
+
+
 Allowed compression algorithms
 ------------------------------
 

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -68,6 +68,79 @@ new messages in the extension handshake:
     } 
 
 
+The ```crequest``` message itself consists of the extension message header
+and the following bencoded payload:
+
+.. parsed-literal::
+    
+    {
+      "algos": [
+        [
+          *<identifier (string)>*,
+          *<bit-array, 1 byte (positive integer)>*
+        ],
+        ...
+      ],
+      "pref": <optional, index (integer)>
+    }
+
+
+Connecting client fills ```algos``` list with supported compression
+algorithms, sorted by preference in descending order. Clients can adjust
+preference based on compression speed/ratio, hardware acceleration support,
+performance and other factors. This list can be empty.
+
+```pref``` field specifies algorithm for compression preferred by client.
+
+Flags in bit-array are defined as follows:
+
+ ==== ===========================================
+ Bit  when set
+ ==== ===========================================
+ 0x01 supports stream mode for decompression
+ 0x02 supports piece mode for decompression
+ 0x04 (reserved)
+ 0x08 (reserved)
+ 0x10 supports stream mode for compression
+ 0x20 supports piece mode for compression
+ 0x40 (reserved)
+ 0x80 (reserved)
+ ==== ===========================================
+
+
+The ```cresponse``` message is send in response to ```crequest```, consists of
+the extension message header and the following bencoded payload:
+
+.. parsed-literal::
+    
+    {
+      "recv": [
+        *<identifier (string)>*,
+        *<0x01 or 0x02 for stream/piece mode (positive integer)>*
+      ],
+      "send": [
+        *<identifier (string)>*,
+        *<0x10 0r 0x20 for stream/piece mode (positive integer)>*
+      ],
+      "resend": *<optional, boolean (positive integer)>*
+    }
+
+
+Receiving client select appropriate algorithms and compression modes and
+sets ```recv``` and ```send``` fields, which also can be empty. After that
+message compression must be enabled/disabled between two clients. Responding
+client can ask requesting client to send new request by settings ```resend```
+field is set to 1.
+
+The ```cpiece``` has same contents as ```piece``` message, but payload is
+compressed, in piece mode both types of messages can be used.
+
+Connecting client can send ```crequest``` message at any point of time,
+but should do that right after handshake. Responding client must respond
+to that ```cresponse``` message, but also can send that message at any
+point of time to disable compression or ask for new request.
+
+
 Allowed compression algorithms
 ------------------------------
 

--- a/beps/bep_0056.rst
+++ b/beps/bep_0056.rst
@@ -8,11 +8,9 @@
 :Created: 31-Sep-2021
 :Post-History: 
 
-Abstract
-========
-This extension adds a capability for clients to negotiate and use
-compression methods for data streams or torrent pieces, effectively
-improving bandwidth for supporting clients.
+Data compression extension adds a capability for clients to negotiate
+and use compression algorithms to improve bandwidth.
+
 
 Rationale
 =========
@@ -26,53 +24,14 @@ distribution. For example: Organizations using Bittorrent for software
 distribution needs to have centralized storage for new customers, no
 matter how many customers have the same software already.
 
-Extension header
-================
 
-This extension uses the extension protocol (specified in `BEP 0010`_)
-to advertise client capability of using chunk compression. It defines
-following items in the extension protocol handshake message:
-+-------+-----------------------------------------------------------+
-| name  | description                                               |
-+=======+===========================================================+
-| c     | Dictionary of supported compression algorithms which maps |
-|       | its identifiers to its priority (unsigned 8-bit integer), |
-|       | clients can adjust it based on compression speed/ratio,   |
-|       | hardware support, performance, and power mode et cetera.  |
-|       | Priority set to zero means that the compression algorithm |
-|       | is not supported or disabled by user, the client must     |
-|       | ignore unknown algorithms.                                |
-+-------+-----------------------------------------------------------+
-
-
-
-The compression algorithm is selected by taking the dictionary item with
-highest priority from intersection of items supported by both peers,
-if there isn't any suitable compression algorithm - compression will be disabled.
-
-Example of extension handshake message:
-
-::
-
-  {
-    'c': {
-      'p_zstd': 255,
-      's_zstd': 153,
-      'p_lz4': 106,
-      'p_density': 70,
-      's_lz4': 41,
-      's_density': 37
-    }
-  }
-
-
-Compression methods
+Compression modes
 ===================
-Extension provides two approaches (methods) to compression, which have
+Extension provides two approaches (modes) to compression, which have
 their own trade-offs, so choice between these should be made by clients
 on per-torrent basis, using its metadata (properties like piece size).
 
-With **by-piece compression** method, client must compress each piece
+With **by-piece compression** mode, client must compress each piece
 individually, which lowers overall compression ratio but result can
 be stored in cache and reused, probably providing more efficiency.
 If the client is caching compressed pieces in memory, then it can be
@@ -81,7 +40,7 @@ compression. To reduce piece re-compression, client should raise
 current algorithm's priority during handshake. This method has low
 efficiency with pieces smaller than 4 MB.
 
-Clients using **stream compression** method instead compresses whole
+Clients using **stream compression** mode instead compresses whole
 data stream, so compression ratio should be higher. During handshake,
 clients should lower or raise algorithm's priority depending on expected
 factors that could impact compression efficiency and performance. This


### PR DESCRIPTION
> When Bittorrent was created, compression algorithms was slow and expensive, so user must have share uncompressed files or compress it manually to ZIP/RAR/etc.
> 
> Now people still share files in .zip archives (or even in .rar, yikes!), which takes additional space and needs to be uncompressed to somewhere. Instead, why shouldn't we compress torrent pieces on-the-fly?
> 
> We have fast compression algorithms like LZO, LZ4, Snappy and Zstandard, which allows torrenting uncompressed files directly, yet not sacrifing upload speed like if it was pre-compressed.

Discuss here: #124