### PR TITLE
Fix the bencoded example of a v2 encoded torrent

### DIFF
--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -201,7 +201,7 @@ Example:
     
 Bencoded for fileA only::
 
-    d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d5:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
+    d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
 
 
 ``length``


### PR DESCRIPTION
'length' has 6 characters, not 5!