### PR TITLE
Clarify that non power-of-two lengths are valid

### DIFF
--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -444,7 +444,8 @@ to the leaf and piece layers. Index is the offset in hashes
 of the first requested hash in the base layer.
 Index MUST be a multiple of length, this includes zero.
 Length is the number of hashes to include from the base layer.
-Length MUST be equal-to-or-greater-than two and a power of two.
+Length MUST be equal-to-or-greater-than two and a power of two unless it
+gets truncated by the end of a layer.
 Length SHOULD NOT be greater than 512. Proof layers is the
 number of ancestor layers to include. Note that the limits imposed on
 index and length above mean that at-most one uncle hash is needed

--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -445,7 +445,7 @@ of the first requested hash in the base layer.
 Index MUST be a multiple of length, this includes zero.
 Length is the number of hashes to include from the base layer.
 Length MUST be equal-to-or-greater-than two and a power of two unless it
-gets truncated by the end of a layer.
+gets truncated by the end of the layer.
 Length SHOULD NOT be greater than 512. Proof layers is the
 number of ancestor layers to include. Note that the limits imposed on
 index and length above mean that at-most one uncle hash is needed


### PR DESCRIPTION
If the layer has 7 pieces, and clients wish to request this in chunks, it is valid to send two messages:
1. index = 0, length = 4
2. index = 4, length = 3

Let's hardcode this into the spec as a 'MUST' so anyone implementing the spec has unambiguous
guidance. Existing clients  adhere to this as far as I can make out.

Addresses https://github.com/bittorrent/bittorrent.org/issues/128