### PR TITLE
Document that duplicated keys in bencode directory are not allowed

### DIFF
--- a/beps/bep_0003.html
+++ b/beps/bep_0003.html
@@ -112,7 +112,7 @@ zero, such as <tt class="docutils literal">i03e</tt>, are invalid, other than
 bencoded) followed by an 'e'. For example <tt class="docutils literal">l4:spam4:eggse</tt>
 corresponds to ['spam', 'eggs'].</li>
 <li>Dictionaries are encoded as a 'd' followed by a list of alternating
-keys and their corresponding values followed by an 'e'. For example,
+unique keys and their corresponding values followed by an 'e'. For example,
 <tt class="docutils literal">d3:cow3:moo4:spam4:eggse</tt> corresponds to {'cow': 'moo',
 'spam': 'eggs'} and <tt class="docutils literal">d4:spaml1:a1:bee</tt> corresponds to
 {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order

--- a/beps/bep_0003.rst
+++ b/beps/bep_0003.rst
@@ -69,7 +69,7 @@ bencoding
   corresponds to ['spam', 'eggs'].
 
 - Dictionaries are encoded as a 'd' followed by a list of alternating
-  keys and their corresponding values followed by an 'e'. For example,
+  unique keys and their corresponding values followed by an 'e'. For example,
   ``d3:cow3:moo4:spam4:eggse`` corresponds to {'cow': 'moo',
   'spam': 'eggs'} and ``d4:spaml1:a1:bee`` corresponds to
   {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order

--- a/beps/bep_0052.html
+++ b/beps/bep_0052.html
@@ -114,7 +114,7 @@ zero, such as <tt class="docutils literal">i03e</tt>, are invalid, other than
 bencoded) followed by an 'e'. For example <tt class="docutils literal">l4:spam4:eggse</tt>
 corresponds to ['spam', 'eggs'].</li>
 <li>Dictionaries are encoded as a 'd' followed by a list of alternating
-keys and their corresponding values followed by an 'e'. For example,
+unique keys and their corresponding values followed by an 'e'. For example,
 <tt class="docutils literal">d3:cow3:moo4:spam4:eggse</tt> corresponds to {'cow': 'moo',
 'spam': 'eggs'} and <tt class="docutils literal">d4:spaml1:a1:bee</tt> corresponds to
 {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order

--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -80,7 +80,10 @@ bencoding
   'spam': 'eggs'} and ``d4:spaml1:a1:bee`` corresponds to
   {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order
   (sorted as raw strings, not alphanumerics).
-  Duplicate keys are not allowed, for example ``d3:keyi1e3:keyi2ee``
+  Duplicate keys in same directory are not allowed,
+  for example ``d3:keyi1e3:keyi2ee``.
+  But same keys in different directory doesn't have this limitation,
+  for example, `{'cow': 'moo', 'spam': {'cow': 'eggs'}}`
   
 
 Note that in the context of bencoding strings including dictionary keys

--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -80,6 +80,7 @@ bencoding
   'spam': 'eggs'} and ``d4:spaml1:a1:bee`` corresponds to
   {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order
   (sorted as raw strings, not alphanumerics).
+  Duplicate keys are not allowed, for example ``d3:keyi1e3:keyi2ee``
   
 
 Note that in the context of bencoding strings including dictionary keys

--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -75,15 +75,11 @@ bencoding
   corresponds to ['spam', 'eggs'].
 
 - Dictionaries are encoded as a 'd' followed by a list of alternating
-  keys and their corresponding values followed by an 'e'. For example,
+  unique keys and their corresponding values followed by an 'e'. For example,
   ``d3:cow3:moo4:spam4:eggse`` corresponds to {'cow': 'moo',
   'spam': 'eggs'} and ``d4:spaml1:a1:bee`` corresponds to
   {'spam': ['a', 'b']}. Keys must be strings and appear in sorted order
   (sorted as raw strings, not alphanumerics).
-  Duplicate keys in same directory are not allowed,
-  for example ``d3:keyi1e3:keyi2ee``.
-  But same keys in different directory doesn't have this limitation,
-  for example, `{'cow': 'moo', 'spam': {'cow': 'eggs'}}`
   
 
 Note that in the context of bencoding strings including dictionary keys


### PR DESCRIPTION
https://github.com/bittorrent/bittorrent.org/issues/153

here `d3:keyi1e3:keyi2ee` or `d3:keyi2e3:keyi1ee` are same directory but can have different bencode content.

This may confusing info_hash generator. save torrent will result into different info_hash