### PR TITLE
update Makefile, docutils rename `rst2html.py` to `rst2html` in newer version

### DIFF
--- a/beps/Makefile
+++ b/beps/Makefile
@@ -63,7 +63,7 @@ BEPS= \
 
 all:	$(BEPS)
 
-RST2HTML ?= rst2html.py
+RST2HTML ?= rst2html
 
 %.html:%.rst_post
 	$(RST2HTML) --template=template.txt --pep-base-url=http://www.bittorrent.org/beps/ --cloak-email-addresses --link-stylesheet --stylesheet=../css/bep.css --no-toc-backlinks $? >$@ --traceback


### PR DESCRIPTION
in new version of docutils it's `rst2html` instead of `rst2html.py`

https://github.com/docutils/docutils/blob/ff0b419256d6b7bfdd4363dd078c2255701de605/docutils/pyproject.toml#L91

```toml
[project.scripts]
docutils = "docutils.__main__:main"
rst2html = "docutils.core:rst2html"
```