### PR TITLE
Correct invalid Bencoded info header in bep_0052

### DIFF
--- a/beps/bep_0052.html
+++ b/beps/bep_0052.html
@@ -221,7 +221,7 @@ a zero-length key with a dictionary containing a <tt class="docutils literal">le
 </pre>
 <p>Bencoded for fileA only:</p>
 <pre class="literal-block">
-d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d5:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
+d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
 </pre>
 <dl class="docutils">
 <dt><tt class="docutils literal">length</tt></dt>

--- a/beps/bep_0052.rst
+++ b/beps/bep_0052.rst
@@ -201,7 +201,7 @@ Example:
     
 Bencoded for fileA only::
 
-    d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d5:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
+    d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee
 
 
 ``length``


### PR DESCRIPTION
The info header for fileA was improperly encoded, as it had `5:length` instead of `6:length`. This changes `d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d5:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee` to `d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeeeee` in the appropriate files.