### PR TITLE
chore: fix typos

### DIFF
--- a/beps/bep_0015.html
+++ b/beps/bep_0015.html
@@ -55,7 +55,7 @@
 </table>
 <div class="section" id="introduction">
 <h1>Introduction</h1>
-<p>To discover other peers in a swarm a client announces it's existance
+<p>To discover other peers in a swarm a client announces it's existence
 to a tracker.  The HTTP protocol is used and a typical request
 contains the following parameters: info_hash, key, peer_id, port,
 downloaded, left, uploaded and compact.  A response contains a list of

--- a/beps/bep_0015.rst
+++ b/beps/bep_0015.rst
@@ -11,7 +11,7 @@
 Introduction
 ============
 
-To discover other peers in a swarm a client announces it's existance
+To discover other peers in a swarm a client announces it's existence
 to a tracker.  The HTTP protocol is used and a typical request
 contains the following parameters: info_hash, key, peer_id, port,
 downloaded, left, uploaded and compact.  A response contains a list of


### PR DESCRIPTION
I encounter some typos while reading specs of Bittorrent protocol.